### PR TITLE
Import Jfoenix to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,8 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
+
+    compile 'com.jfoenix:jfoenix:9.0.10'
 }
 
 shadowJar {


### PR DESCRIPTION
Import Jfoenix to build.gradle file so that new changes to the fxml files from the Jfoenix library is compilable. Essentially, Jfoenix is a library of nice UI components and animation that will make GreenTea look nicer.

To import jfoenix to Scenebuilder, please follow this guide until 7:30:
https://www.youtube.com/watch?v=S5Vb5r1_zVU

Or you can follow these instructions:

1. Download Jfoenix jar file from https://github.com/jfoenixadmin/JFoenix
2. Open one of the fxml files with Scene builder 
3. On the top of the left panel, click on the cog wheel next to the word "Library"
4. Click on JAR/FXML manager 
5. Click on Add library/FXML from file system
6. Find the Jar file you downloaded in step 1 and import 
7. Make sure all components are checked and click import
8. Done